### PR TITLE
Run mypy during pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
 
 repos:
 -   repo: https://github.com/python/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
     - id: black
 -   repo: https://github.com/fsfe/reuse-tool

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,3 +30,17 @@ repos:
         name: lint (code)
         types: [python]
         exclude: "^(docs/|examples/|setup.py$)"
+- repo: local
+  hooks:
+    - id: mypy
+      name: mypy
+      entry: "mypy --no-warn-unused-ignores jepler_udecimal"
+      language: python
+      additional_dependencies: ["mypy==0.910"]
+      types: [python]
+      # use require_serial so that script
+      # is only called once per commit
+      require_serial: true
+      # Print the number of files as a sanity-check
+      verbose: true
+      pass_filenames: false

--- a/jepler_udecimal/__init__.py
+++ b/jepler_udecimal/__init__.py
@@ -141,7 +141,7 @@ try:
 
     DecimalTuple = _namedtuple("DecimalTuple", "sign digits exponent")
 except ImportError:
-    DecimalTuple = lambda *args: args
+    DecimalTuple = lambda *args: args  # type: ignore
 
 # Rounding
 ROUND_DOWN = "ROUND_DOWN"
@@ -3574,7 +3574,7 @@ class Context(object):
             self._ignored_flags.remove(flag)
 
     # We inherit object.__hash__, so we must deny this explicitly
-    __hash__ = None
+    __hash__ = None  # type: ignore
 
     def Etiny(self):
         """Returns Etiny (= Emin - prec + 1)"""
@@ -5372,7 +5372,7 @@ ExtendedContext = Context(
 try:
     import re
 except:
-    import ure as re
+    import ure as re  # type: ignore
 
 _parser = re.compile(  # A numeric string consists of:
     r"([-+])?"  # an optional sign, followed by either...    # 1


### PR DESCRIPTION
based on https://jaredkhan.com/blog/mypy-pre-commit this adds mypy (non-strict) during pre-commit. It might be useful in considering how we can apply this to CircuitPython libraries.

 * the library name has to be called out in the mypy commandline within pre-commit-config.yaml
 * any requirements must also be called out

This means that the pre-commit file would always be different between projects, which is :-1: 

Using a separate script as suggested at https://jaredkhan.com/blog/mypy-pre-commit might make still allow the pre-commit-confg file to remain identical across libs; it could `pip install -r requirements_dev.txt` and figure out the package name somehow (we must have that somewhere already)